### PR TITLE
Added an appdata file. It's incomplete though:

### DIFF
--- a/data/labyrinth.appdata.xml
+++ b/data/labyrinth.appdata.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<application>
+    <id type="desktop">labyrinth.desktop</id>
+    <licence>CC0</licence>
+    <name>Labyrinth</name>
+    <summary>A light weight mind mapping tool</summary>
+    <description>
+        <p>
+            Labyrinth is a lightweight mind-mapping tool, written in Python using Gtk and
+            Cairo to do the drawing. It is intended to be as light and intuitive as
+            possible, but still provide a wide range of powerful features.
+        </p>
+
+        <p>
+            A mind-map is a diagram used to represent words, ideas, tasks or other items
+            linked to and arranged radially around a central key word or idea. It is used
+            to generate, visualize, structure and classify ideas, and as an aid in study,
+            organization, problem solving, and decision making (From Wikipedia).
+        </p>
+
+        <p>
+            Currently, Labyrinth provides 3 different types of thoughts, or nodes - Text,
+            Image and Drawing. Text is the basic standard text node. Images allow you to
+            insert and scale any supported image file (PNG, JPEG, SVG). Drawings are for
+            those times when you want to illustrate something, but don't want to fire up a
+            separate drawing program. It allows you to quickly and easily sketch very
+            simple line diagrams.
+        </p>
+
+    </description>
+    <!-- TODO: The screenshot URL will need to be changed to wherever the new screenshots are placed. They must be in 16:9 aspect ratio for appstream. The current ones are too small and appdata-validate gives errors.  -->
+    <screenshots>
+        <screenshot type="default">http://labyrinth.googlecode.com/svn/wiki/screenshot-0.5.0d.png</screenshot>
+    </screenshots>
+    <url type="homepage">https://github.com/labyrinth-team/labyrinth</url>
+    <updatecontact>Don@Scorgie.org</updatecontact>
+</application>
+


### PR DESCRIPTION
New screenshots are required, which must be in 16:9 aspect ratio for
appdata. The older screenshots aren't of the 0.6 version, and aren't of
the correct aspect ratio either.

Refer:
http://blogs.gnome.org/hughsie/2013/10/08/how-to-take-169-screenshots/
https://lists.fedoraproject.org/pipermail/devel/2013-September/188799.html

I can generate screenshots on my machine and send them to you if that'll help. Also, I haven't tweaked the install scripts to install the appdata file. It needs to go into /usr/share/appdata/ as the above links describe. 

I'm the Fedora maintainer for labyrinth. It's available in the repos now. If you can host the screenshots somewhere, i'll go ahead and immediately push an update so a complete entry can be shown in gnome-software. 
