### PR TITLE
Radically revamp how files are opened/saved

### DIFF
--- a/data/labyrinth-ui.xml
+++ b/data/labyrinth-ui.xml
@@ -3,6 +3,7 @@
     <menu action="FileMenu">
       <menuitem action="Export"/>
       <menuitem action="ExportMap"/>
+      <menuitem action="ExportMapAs"/>
       <separator/>
       <menuitem action="Close"/>
     </menu>

--- a/data/labyrinth-ui.xml
+++ b/data/labyrinth-ui.xml
@@ -2,8 +2,8 @@
   <menubar name="MenuBar">
     <menu action="FileMenu">
       <menuitem action="Export"/>
-      <menuitem action="ExportMap"/>
-      <menuitem action="ExportMapAs"/>
+      <menuitem action="Save"/>
+      <menuitem action="SaveAs"/>
       <separator/>
       <menuitem action="Close"/>
     </menu>

--- a/labyrinth
+++ b/labyrinth
@@ -21,5 +21,11 @@
 # Boston, MA  02110-1301  USA
 #
 
+import sys
 from labyrinth_lib import main
-main()
+
+filepath = None
+if len(sys.argv) == 2:
+  filepath = sys.argv[1]
+main(filepath=filepath)
+

--- a/labyrinth_lib/Browser.py
+++ b/labyrinth_lib/Browser.py
@@ -51,7 +51,7 @@ class Browser (gtk.Window):
     COL_TITLE = 1
     COL_MODTIME = 2
 
-    def __init__(self, start_hidden, tray_icon):
+    def __init__(self, start_hidden, tray_icon, filepath=None):
         super(Browser, self).__init__()
         self.glade=gtk.glade.XML(utils.get_data_file_name('labyrinth.glade'))
         self.view = self.glade.get_widget ('MainView')

--- a/labyrinth_lib/MainWindow.py
+++ b/labyrinth_lib/MainWindow.py
@@ -60,6 +60,7 @@ class LabyrinthWindow (gobject.GObject):
                                           (gobject.TYPE_OBJECT, )))
 
     def __init__ (self, filename, imported=False):
+        self.save_file = filename
         super(LabyrinthWindow, self).__init__()
 
         # First, construct the MainArea and connect it all up
@@ -185,10 +186,10 @@ class LabyrinthWindow (gobject.GObject):
         # Other stuff
         self.width, self.height = self.main_window.get_size ()
 
-        # if we import, we dump the old filename to create a new hashed one
-        self.save_file = None
-        if not imported:
-            self.save_file = filename
+#        # if we import, we dump the old filename to create a new hashed one
+#        self.save_file = None
+#        if not imported:
+#            self.save_file = filename
 
         self.maximised = False
         self.view_type = 0
@@ -208,10 +209,10 @@ class LabyrinthWindow (gobject.GObject):
                 ('FileMenu', None, _('File')),
                 ('Export', None, _('Export as Image'), None,
                  _("Export your map as an image"), self.export_cb),
-                ('ExportMap', gtk.STOCK_SAVE_AS, _('Export Map'), '<control>S',
-                 _("Export your map as XML"), self.export_map_cb),
-                ('ExportMapAs', gtk.STOCK_SAVE_AS, _('Export Map As...'), None,
-                 _("Export your map as XML"), self.export_map_as_cb),
+                ('Save', gtk.STOCK_SAVE_AS, _('Save'), '<control>S',
+                 _("Save"), self.export_map_cb),
+                ('SaveAs', gtk.STOCK_SAVE_AS, _('Save As...'), None,
+                 _("Save As..."), self.export_map_as_cb),
                 ('Close', gtk.STOCK_CLOSE, None, '<control>W',
                  _('Close the current window'), self.close_window_cb),
                 ('EditMenu', None, _('_Edit')),
@@ -495,8 +496,9 @@ class LabyrinthWindow (gobject.GObject):
     def close_window_cb (self, event):
         self.SaveTimer.cancel = True
         self.main_window.hide ()
-        self.MainArea.save_thyself ()
+#        self.MainArea.save_thyself ()
         del (self)
+        gtk.main_quit ()
 
     def doc_del_cb (self, widget):
         self.emit ('window_closed', None)
@@ -517,41 +519,26 @@ class LabyrinthWindow (gobject.GObject):
     def doc_save_cb (self, widget, doc, top_element):
         save_string = self.serialize_to_xml(doc, top_element)
         if not self.save_file:
-            hsh = hashlib.sha256 (save_string)
-            save_loc = utils.get_save_dir ()
-            self.save_file = os.path.join (save_loc, hsh.hexdigest() + ".map")
-            counter = 1
-            while os.path.exists(self.save_file):
-                print "Warning: Duplicate File. Saving to alternative"
-                alt_name = "Dup" + str(counter) + hsh.hexdigest() + ".map"
-                self.save_file = save_loc + os.path.join (save_loc, alt_name)
-                counter += 1
+            self.export_map_as_cb(None)
 
         with open(self.save_file, 'w') as f:
             f.write(save_string)
         self.emit ('file_saved', self.save_file, self)
 
     def export_map_cb(self, event):
-        if 'last_export_filename' not in self.__dict__:
+        if self.save_file is None:
             return self.export_map_as_cb(event)
-        filename = self.last_export_filename
         self.MainArea.save_thyself ()
-        tf = tarfile.open (filename, "w")
-        tf.add (self.save_file, os.path.basename(self.save_file))
-        for t in self.MainArea.thoughts:
-            if isinstance(t, ImageThought.ImageThought):
-                tf.add (t.filename, 'images/' + os.path.basename(t.filename))
-        tf.close()
 
     def export_map_as_cb(self, event):
         chooser = gtk.FileChooserDialog(title=_("Save File As"), action=gtk.FILE_CHOOSER_ACTION_SAVE, \
-                                                                        buttons=(gtk.STOCK_CANCEL, gtk.RESPONSE_CANCEL, gtk.STOCK_OPEN, gtk.RESPONSE_OK))
-        chooser.set_current_name ("%s.mapz" % self.main_window.title)
+                                                                        buttons=(gtk.STOCK_CANCEL, gtk.RESPONSE_CANCEL, gtk.STOCK_SAVE_AS, gtk.RESPONSE_OK))
+        chooser.set_current_name ("%s.map" % self.main_window.title)
         response = chooser.run()
         if response == gtk.RESPONSE_OK:
             filename = chooser.get_filename ()
-            self.last_export_filename = filename
-            self.export_map_cb(event)
+            self.save_file = filename
+            self.MainArea.save_thyself()
         chooser.destroy()
 
     def parse_file (self, filename):

--- a/labyrinth_lib/__init__.py
+++ b/labyrinth_lib/__init__.py
@@ -1,5 +1,6 @@
 __version__ = "0.7a1"
 
-def main():
+def main(filepath=None):
+    print('init main')
     from .launch import main
-    main()
+    main(filepath=filepath)

--- a/labyrinth_lib/launch.py
+++ b/labyrinth_lib/launch.py
@@ -4,6 +4,7 @@ import optparse
 import os
 import os.path as osp
 import sys
+import MainWindow
 
 pygtk.require('2.0')
 
@@ -47,7 +48,21 @@ def set_win_taskbar_app():
         # That function doesn't exist on Windows XP
         pass
 
-def main():
+def main(filepath=None):
+    print('launch.main')
+    prepare_locale()
+    print('after prepare locale')
+#    MapBrowser = Browser.Browser (
+#        start_hidden = False,
+#        tray_icon = False,
+#        filepath=filepath
+#    )
+    mainWindow = MainWindow.LabyrinthWindow(filename=filepath)
+    mainWindow.show()
+    gtk.main()
+    print('end of launch.main')
+
+def main_old():
     parser = optparse.OptionParser()
     parser.add_option("--use-tray-icon", dest="tray_icon",
             action="store_true", default=False)


### PR DESCRIPTION
Address https://github.com/labyrinth-team/labyrinth/issues/17

It's not ideal, since the first time you open the doc, you still have to specify the path (cf, if I could open directly from the path I want to save to would be better), but at least it works around the repeated ctrl-s dialog appearing issue.