### PR TITLE
Add an updated .appdata file

### DIFF
--- a/data/labyrinth.appdata.xml
+++ b/data/labyrinth.appdata.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<application>
+    <id type="desktop">labyrinth.desktop</id>
+    <metadata_license>CC0-1.0</metadata_license>
+    <project_license>GPL-2.0</project_license>
+    <name>Labyrinth</name>
+    <summary>A light weight mind mapping tool</summary>
+    <description>
+        <p>
+            Labyrinth is a lightweight mind-mapping tool, written in Python using Gtk and
+            Cairo to do the drawing. It is intended to be as light and intuitive as
+            possible, but still provide a wide range of powerful features.
+        </p>
+
+        <p>
+            A mind-map is a diagram used to represent words, ideas, tasks or other items
+            linked to and arranged radially around a central key word or idea. It is used
+            to generate, visualize, structure and classify ideas, and as an aid in study,
+            organization, problem solving, and decision making (From Wikipedia).
+        </p>
+
+        <p>
+            Currently, Labyrinth provides 3 different types of thoughts, or nodes - Text,
+            Image and Drawing. Text is the basic standard text node. Images allow you to
+            insert and scale any supported image file (PNG, JPEG, SVG). Drawings are for
+            those times when you want to illustrate something, but don't want to fire up a
+            separate drawing program. It allows you to quickly and easily sketch very
+            simple line diagrams.
+        </p>
+
+    </description>
+
+    <content_rating type="oars-1.1" />
+
+    <releases>
+      <release date="2012-11-02" version="0.6"/>
+    </releases>
+
+    <screenshots>
+      <screenshot>
+        <image type="source">https://screenshots.debian.net/screenshots/000/009/362/large.png</image>
+        <image type="source">https://screenshots.debian.net/screenshots/000/009/194/large.png</image>
+      </screenshot>
+    </screenshots>
+
+    <url type="homepage">https://github.com/labyrinth-team/labyrinth</url>
+    <updatecontact>Don@Scorgie.org</updatecontact>
+</application>
+

--- a/install_data_files.sh
+++ b/install_data_files.sh
@@ -14,5 +14,8 @@ install -m 644 data/labyrinth.svg $DESTDIR/usr/share/icons/hicolor/scalable/apps
 echo "Installing .desktop file"
 install -D -m 755 data/labyrinth.desktop $DESTDIR/usr/share/applications/labyrinth.desktop
 
+echo "Installing .appdata.xml file"
+install -D -m 644 data/labyrinth.appdata.xml $DESTDIR/usr/share/appdata/labyrinth.appdata.xml
+
 echo "Installing translations"
 make -C po localedir=$DESTDIR/usr/share/locale install


### PR DESCRIPTION
I know that https://github.com/labyrinth-team/labyrinth/pull/11 already includes an appdata file, but I've updated it with new screenshots from Debian, and modernized it as I was submitting this application to Flathub. (https://github.com/flathub/flathub/pull/528, I welcome any help there btw!)

We can also iterate on a better place to host those screenshots/better screenshots once we have a basic appdata file in place.
Thanks for considering.